### PR TITLE
Implement correction feature

### DIFF
--- a/Assets/Scripts/Advanced Layout Element/Editor/AdvancedLayoutElementEditor.cs
+++ b/Assets/Scripts/Advanced Layout Element/Editor/AdvancedLayoutElementEditor.cs
@@ -103,6 +103,9 @@ namespace AP.Editor.UI
             var weightProp = property.FindPropertyRelative("m_Weight");
             var overrideProp = property.FindPropertyRelative("m_Override");
 
+            string correctionFieldName = AdvancedLayoutElement.Property.CorrectionFieldName;
+            var correctionProperty = property.FindPropertyRelative(correctionFieldName);
+
             var currentType = (LayoutProperty)typeProp.enumValueIndex;
 
             Rect marchingRect = position;
@@ -166,6 +169,7 @@ namespace AP.Editor.UI
                 DoOverrideProperty(overrideProp, ref marchingRect);
                 DoProperty(valueProp, ref marchingRect);
                 DoProperty(readOnlyProp, ref marchingRect);
+                DoProperty(correctionProperty, ref marchingRect);
             }
             EditorGUI.EndProperty();
         }

--- a/Assets/Scripts/Advanced Layout Element/Runtime/AdvancedLayoutElement.Property.cs
+++ b/Assets/Scripts/Advanced Layout Element/Runtime/AdvancedLayoutElement.Property.cs
@@ -44,6 +44,13 @@ namespace AP.UI
             [Tooltip("The current value that this property is set to")]
             [SerializeField] float m_Value = 0;
 
+            [SerializeField] private float _correction;
+
+            // Make it internal, when u'll configure this runtime assembly
+            // to be visible to editor's assembly.
+            // see msdn: Friend assemblies.
+            public static string CorrectionFieldName => nameof(_correction);
+
             public LayoutProperty Type
             {
                 get
@@ -72,7 +79,8 @@ namespace AP.UI
                 }
             }
 
-            public float Value => (m_Enabled) ? m_Value * m_Weight : -1;
+            //public float Value => (m_Enabled) ? m_Value * m_Weight : -1;
+            public float Value => (m_Enabled) ? (m_Value + _correction) * m_Weight : -1;
 
             /// <summary>
             /// the raw value refers to the value of the property without any weight applied


### PR DESCRIPTION
Hi. I think this helpful tool is missing some stuff:

1. Manual correction of release value of a property. (implemented in this PR)
2. I suggest to lock (make it readonly) the "value" properties on the inspector when "Override" component is assigned. (by GUI.enabled).
3. Maybe rename the "Read Only" property in inspector to something more convenient?  for those (like me)) who not reads tooltips.

P.S. Too lazy to create issues )

![image](https://github.com/apilola/advanced-layout-element/assets/41789108/84bc809b-92ec-41a4-8747-1b1479ccd289)
